### PR TITLE
pm: suspend: read suspend time from timekeeping

### DIFF
--- a/drivers/input/touchscreen/ektf2k.c
+++ b/drivers/input/touchscreen/ektf2k.c
@@ -395,9 +395,9 @@ static long elan_iap_ioctl(struct file *filp, unsigned int cmd,
 	case IOCTL_RESET:
 		// modify
 		gpio_set_value(SYSTEM_RESET_PIN_SR, 0);
-		msleep(20);
+		usleep_range(19500,20000);
 		gpio_set_value(SYSTEM_RESET_PIN_SR, 1);
-		msleep(5);
+		usleep_range(5000,5500);
 		printk(KERN_EMERG "elan_iap_ioctl : IOCTL_RESET\n ");
 		break;
 	case IOCTL_IAP_MODE_LOCK:
@@ -651,7 +651,7 @@ IAP_RESTART:
 	if (res != sizeof(data)) {
 		printk("[ELAN] dummy error code = %d\n", res);
 	}
-	msleep(10);
+	usleep_range(10000, 10500);
 
 	// Start IAP
 	for (iPage = 1; iPage <= PageNum; iPage++) {
@@ -730,7 +730,7 @@ IAP_RESTART:
 			print_progress(iPage, ic_num, i);
 		}
 
-		msleep(10);
+		usleep_range(10000, 10500);
 	} // end of for(iPage = 1; iPage <= PageNum; iPage++)
 
 	printk("[ELAN] read Hello packet data!\n");
@@ -1782,7 +1782,7 @@ static ssize_t elan_ktf2k_mode_set(struct device *dev,
 			elan_ktf2k_ts_set_mode_state(private_ts->client,
 						     chip_mode_set);
 		}
-		msleep(10);
+		usleep_range(10000, 10500);
 		elan_ktf2k_set_scan_mode(private_ts->client, 1);
 	} else {
 		elan_ktf2k_ts_set_mode_state(private_ts->client, chip_mode_set);
@@ -1845,7 +1845,7 @@ static ssize_t elan_ktf2k_talking_set(struct device *dev,
 			elan_ktf2k_ts_set_talking_state(private_ts->client,
 							talking_mode_set);
 		}
-		msleep(10);
+		usleep_range(10000, 10500);
 		elan_ktf2k_set_scan_mode(private_ts->client, 1);
 	} else {
 		printk(KERN_EMERG "%s 2127e \n", __func__);
@@ -2017,7 +2017,7 @@ static int __elan_ktf2k_ts_poll(struct i2c_client *client)
 		retry--;
 		if (status == 1) // [Arima Edison] we do not need delay if chip
 				 // work normally
-			msleep(25);
+			usleep_range(19500,20000);
 	} while (status == 1 && retry > 0);
 
 	return (status == 0 ? 0 : -ETIMEDOUT);
@@ -2484,7 +2484,7 @@ static int elan_ktf2k_ts_get_raw_data_disable(struct i2c_client *client)
 		return -EINVAL;
 	}
 
-	msleep(10);
+	usleep_range(10000, 10500);
 
 	return 0;
 }
@@ -2519,7 +2519,7 @@ static int elan_ktf2k_ts_set_mode_state(struct i2c_client *client, int mode)
 			__func__);
 		return -EINVAL;
 	}
-	msleep(1);
+	usleep_range(1000, 1500);
 	return 0;
 }
 /* 53 56 00 01*/
@@ -2562,7 +2562,7 @@ static int elan_ktf2k_ts_set_talking_state(struct i2c_client *client, int mode)
 			__func__);
 		return -EINVAL;
 	}
-	msleep(1);
+	usleep_range(1000, 1500);
 	return 0;
 }
 
@@ -2630,7 +2630,7 @@ static int elan_ktf2k_set_scan_mode(struct i2c_client *client, int mode)
 				__func__, mode);
 			return -EINVAL;
 		}
-		msleep(1);
+		usleep_range(1000, 1500);
 	}
 	return 0;
 }
@@ -2680,9 +2680,9 @@ static int elan_ktf2k_ts_hw_reset(struct i2c_client *client)
 {
 	// touch_debug(DEBUG_INFO, "[ELAN] Start HW reset!\n");
 	gpio_direction_output(SYSTEM_RESET_PIN_SR, 0);
-	msleep(20);
+	usleep_range(19500,20000);
 	gpio_direction_output(SYSTEM_RESET_PIN_SR, 1);
-	msleep(130);
+	msleep(125);
 	return 0;
 }
 
@@ -2879,7 +2879,7 @@ static void elan_ktf2k_ts_report_data(struct i2c_client *client, uint8_t *buf)
 						    private_ts->client,
 						    talking_mode_set);
 					}
-					msleep(10);
+					usleep_range(10000, 10500);
 					elan_ktf2k_set_scan_mode(
 					    private_ts->client, 1);
 				} else {
@@ -2900,7 +2900,7 @@ static void elan_ktf2k_ts_report_data(struct i2c_client *client, uint8_t *buf)
 						    private_ts->client,
 						    talking_mode_set);
 					}
-					msleep(10);
+					usleep_range(10000, 10500);
 				}
 				mutex_unlock(&private_ts->lock); // set lock
 			}
@@ -3061,7 +3061,7 @@ static void elan_ktf2k_ts_check_work_func(struct work_struct *work)
 				elan_ktf2k_ts_set_talking_state(
 				    private_ts->client, talking_mode_set);
 			}
-			msleep(10);
+			usleep_range(10000, 10500);
 			elan_ktf2k_set_scan_mode(private_ts->client, 1);
 		} else {
 			elan_ktf2k_ts_set_mode_state(private_ts->client,
@@ -3796,7 +3796,7 @@ static int elan_ktf2k_ts_resume(struct device *dev)
 					enter into suspend mode.  */
 		{
 			gpio_direction_output(SYSTEM_RESET_PIN_SR, 0);
-			msleep(5);
+			usleep_range(5000,5500);
 			gpio_direction_output(SYSTEM_RESET_PIN_SR, 1);
 			msleep(150);
 
@@ -3824,7 +3824,7 @@ static int elan_ktf2k_ts_resume(struct device *dev)
 					    private_ts->client,
 					    talking_mode_set);
 				}
-				msleep(10);
+				usleep_range(10000, 10500);
 				elan_ktf2k_set_scan_mode(private_ts->client, 1);
 			} else {
 				elan_ktf2k_ts_set_mode_state(private_ts->client,

--- a/drivers/input/touchscreen/ektf2k.c
+++ b/drivers/input/touchscreen/ektf2k.c
@@ -3766,6 +3766,8 @@ static int elan_ktf2k_ts_resume(struct device *dev)
 
 	printk(KERN_EMERG "%s \n", __func__);
 
+	elan_ktf2k_ts_hw_reset(private_ts->client);
+
 	mutex_lock(&private_ts->lock); // set lock
 
 	if (tp_sleep_status == 0) {

--- a/drivers/media/platform/msm/camera_v2/gemini/Makefile
+++ b/drivers/media/platform/msm/camera_v2/gemini/Makefile
@@ -1,4 +1,4 @@
-GCC_VERSION      := $(shell $(CONFIG_SHELL) $(PWD)/scripts/gcc-version.sh $(CROSS_COMPILE)gcc)
+GCC_VERSION      := $(shell $(CONFIG_SHELL) $(srctree)/scripts/gcc-version.sh $(CROSS_COMPILE)gcc)
 ccflags-y += -Idrivers/media/video/msm
 ccflags-y += -Idrivers/media/platform/msm/camera_v2/sensor/io
 

--- a/drivers/media/platform/msm/camera_v2/jpeg_10/Makefile
+++ b/drivers/media/platform/msm/camera_v2/jpeg_10/Makefile
@@ -1,4 +1,4 @@
-GCC_VERSION      := $(shell $(CONFIG_SHELL) $(PWD)/scripts/gcc-version.sh $(CROSS_COMPILE)gcc)
+GCC_VERSION      := $(shell $(CONFIG_SHELL) $(srctree)/scripts/gcc-version.sh $(CROSS_COMPILE)gcc)
 
 ccflags-y += -Idrivers/media/platform/msm/camera_v2/jpeg_10
 

--- a/kernel/power/Kconfig
+++ b/kernel/power/Kconfig
@@ -277,3 +277,10 @@ config SUSPEND_TIME
 	  Prints the time spent in suspend in the kernel log, and
 	  keeps statistics on the time spent in suspend in
 	  /sys/kernel/debug/suspend_time
+
+config SUSPEND_TIME_TIMEKEEPING
+	bool "get suspend time from timekeeping"
+	default y
+	---help---
+	  Get the suspend time in suspend from timekeeping for the archs
+	  that don't support persistent clock.

--- a/kernel/power/suspend_time.c
+++ b/kernel/power/suspend_time.c
@@ -21,6 +21,7 @@
 #include <linux/seq_file.h>
 #include <linux/syscore_ops.h>
 #include <linux/time.h>
+#include <linux/suspend.h>
 
 static struct timespec suspend_time_before;
 static unsigned int time_in_suspend_bins[32];
@@ -70,6 +71,32 @@ static int __init suspend_time_debug_init(void)
 late_initcall(suspend_time_debug_init);
 #endif
 
+#ifdef CONFIG_SUSPEND_TIME_TIMEKEEPING
+static int suspend_time_pm_event(struct notifier_block *notifier,
+				unsigned long pm_event, void *unused)
+{
+	struct timespec after;
+	switch (pm_event) {
+	case PM_SUSPEND_PREPARE:
+		getnstimeofday(&suspend_time_before);
+		break;
+	case PM_POST_SUSPEND:
+		getnstimeofday(&after);
+		after = timespec_sub(after, suspend_time_before);
+		time_in_suspend_bins[fls(after.tv_sec)]++;
+		pr_info("Suspended for %lu.%03lu seconds\n", after.tv_sec,
+			after.tv_nsec / NSEC_PER_MSEC);
+		break;
+	default:
+		break;
+	}
+	return NOTIFY_DONE;
+}
+
+static struct notifier_block suspend_time_pm_notifier_block = {
+	.notifier_call = suspend_time_pm_event,
+};
+#else
 static int suspend_time_syscore_suspend(void)
 {
 	read_persistent_clock(&suspend_time_before);
@@ -95,17 +122,26 @@ static struct syscore_ops suspend_time_syscore_ops = {
 	.suspend = suspend_time_syscore_suspend,
 	.resume = suspend_time_syscore_resume,
 };
+#endif
 
 static int suspend_time_syscore_init(void)
 {
+#ifdef CONFIG_SUSPEND_TIME_TIMEKEEPING
+	register_pm_notifier(&suspend_time_pm_notifier_block);
+#else
 	register_syscore_ops(&suspend_time_syscore_ops);
+#endif
 
 	return 0;
 }
 
 static void suspend_time_syscore_exit(void)
 {
+#ifdef CONFIG_SUSPEND_TIME_TIMEKEEPING
+	unregister_pm_notifier(&suspend_time_pm_notifier_block);
+#else
 	unregister_syscore_ops(&suspend_time_syscore_ops);
+#endif
 }
 module_init(suspend_time_syscore_init);
 module_exit(suspend_time_syscore_exit);


### PR DESCRIPTION
The suspend time will always return 0 on the Arches that don't
support persistent clock. For these Arches we should read the
suspend time from timekeeping realtime interface.

Signed-off-by: Lianwei Wang <a22439@motorola.com>
Reviewed-on: http://gerrit.mot.com/722248
SLTApproved: Slta Waiver <sltawvr@motorola.com>
Tested-by: Jira Key <jirakey@motorola.com>
Reviewed-by: Christopher Fries <cfries@motorola.com>
Submit-Approved: Jira Key <jirakey@motorola.com>
Reviewed-by: Ravi Chebolu <arc095@motorola.com>