### PR TITLE
staging/upstream

### DIFF
--- a/arch/arm/mach-msm/msm_watchdog_v2.c
+++ b/arch/arm/mach-msm/msm_watchdog_v2.c
@@ -281,6 +281,12 @@ static void pet_watchdog_work(struct work_struct *work)
 	struct msm_watchdog_data *wdog_dd = container_of(delayed_work,
 						struct msm_watchdog_data,
 							dogwork_struct);
+
+	if (test_taint(TAINT_DIE) || oops_in_progress) {
+		pr_info("MSM Watchdog Skip Pet Work.\n");
+		return;
+	}
+
 	delay_time = msecs_to_jiffies(wdog_dd->pet_time);
 	if (enable) {
 		if (wdog_dd->do_ipi_ping)

--- a/drivers/bluetooth/bluesleep.c
+++ b/drivers/bluetooth/bluesleep.c
@@ -670,7 +670,8 @@ static int __init bluesleep_init(void)
 	}
 
 	/* Creating read/write "btwake" entry */
-	ent = create_proc_entry("btwake", 0, sleep_dir);
+	ent = create_proc_entry("btwake", S_IRUGO | S_IWUSR | S_IWGRP,
+			sleep_dir);
 	if (ent == NULL) {
 		BT_ERR("Unable to create /proc/%s/btwake entry", PROC_DIR);
 		retval = -ENOMEM;
@@ -680,7 +681,7 @@ static int __init bluesleep_init(void)
 	ent->write_proc = bluepower_write_proc_btwake;
 
 	/* read only proc entries */
-	if (create_proc_read_entry("hostwake", 0, sleep_dir,
+	if (create_proc_read_entry("hostwake", S_IRUGO, sleep_dir,
 				bluepower_read_proc_hostwake, NULL) == NULL) {
 		BT_ERR("Unable to create /proc/%s/hostwake entry", PROC_DIR);
 		retval = -ENOMEM;
@@ -688,7 +689,8 @@ static int __init bluesleep_init(void)
 	}
 
 	/* read/write proc entries */
-	ent = create_proc_entry("proto", 0, sleep_dir);
+	ent = create_proc_entry("proto", S_IRUGO | S_IWUSR | S_IWGRP,
+			sleep_dir);
 	if (ent == NULL) {
 		BT_ERR("Unable to create /proc/%s/proto entry", PROC_DIR);
 		retval = -ENOMEM;
@@ -698,7 +700,7 @@ static int __init bluesleep_init(void)
 	ent->write_proc = bluesleep_write_proc_proto;
 
 	/* read only proc entries */
-	if (create_proc_read_entry("asleep", 0,
+	if (create_proc_read_entry("asleep", S_IRUGO,
 			sleep_dir, bluesleep_read_proc_asleep, NULL) == NULL) {
 		BT_ERR("Unable to create /proc/%s/asleep entry", PROC_DIR);
 		retval = -ENOMEM;

--- a/drivers/char/adsprpc.c
+++ b/drivers/char/adsprpc.c
@@ -1473,7 +1473,7 @@ static void __exit fastrpc_device_exit(void)
 	unregister_chrdev_region(me->dev_no, 1);
 }
 
-module_init(fastrpc_device_init);
+late_initcall(fastrpc_device_init);
 module_exit(fastrpc_device_exit);
 
 MODULE_LICENSE("GPL v2");

--- a/drivers/slimbus/slimbus.c
+++ b/drivers/slimbus/slimbus.c
@@ -2752,6 +2752,18 @@ int slim_reconfigure_now(struct slim_device *sb)
 	u32 segdist;
 	struct slim_pending_ch *pch;
 
+	/*
+	 * If there are no pending changes from this client, avoid sending
+	 * the reconfiguration sequence
+	 */
+	if (sb->pending_msgsl == sb->cur_msgsl &&
+		list_empty(&sb->mark_define) &&
+		list_empty(&sb->mark_removal) &&
+		list_empty(&sb->mark_suspend)) {
+		pr_debug("SLIM_CL: skip reconfig sequence");
+		return 0;
+	}
+
 	mutex_lock(&ctrl->sched.m_reconf);
 	/*
 	 * If there are no pending changes from this client, avoid sending


### PR DESCRIPTION
a9e56791028919206cca99a98e67ad264583f913 bluesleep: Set the file permission for /proc/bluetooth/sleep/*
e9e9217b3072f4582956b7012a7a4042af3ee52a slimbus: Fix channel concurrent usage during reconfiguration sequence
449cfb56f32a87f973265b978d79358e856e6beb msm: ADSPRPC: Change driver initialization to late_initcall
9c75f7a717155de1c3c4a30f39d1c9558ea86b46 arm: msm: watchdog: skip watchdog petting in panic
